### PR TITLE
057: add GitHub Pages — landing + docs

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>zshield — Documentation</title>
+  <meta name="description" content="zshield planned CLI commands and usage documentation.">
+  <link rel="stylesheet" href="https://zarlcorp.github.io/shared.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+
+    <nav class="nav">
+      <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
+      <a href="index.html">zshield</a>
+      <a href="https://github.com/zarlcorp/zshield">GitHub</a>
+    </nav>
+
+    <div class="doc-content">
+
+      <h1>zshield docs</h1>
+
+      <blockquote>These commands are planned &mdash; zshield is not yet released.</blockquote>
+
+      <h2>CLI commands</h2>
+
+      <h3>zshield start</h3>
+      <p>Start the DNS resolver daemon. Listens on localhost and intercepts DNS queries, blocking domains that match configured blocklists.</p>
+      <pre><code>$ zshield start</code></pre>
+
+      <h3>zshield</h3>
+      <p>Attach the interactive TUI dashboard. Shows real-time query log, blocking stats, and quick access to allow/deny overrides.</p>
+      <pre><code>$ zshield</code></pre>
+
+      <h3>zshield status</h3>
+      <p>Print current blocking statistics &mdash; total queries, blocked count, top blocked domains.</p>
+      <pre><code>$ zshield status</code></pre>
+
+      <h3>zshield allow &lt;domain&gt;</h3>
+      <p>Whitelist a domain. Queries for this domain will always resolve normally, even if it appears on a blocklist.</p>
+      <pre><code>$ zshield allow example.com</code></pre>
+
+      <h3>zshield block &lt;domain&gt;</h3>
+      <p>Blacklist a domain. Queries for this domain will always be blocked, regardless of blocklists.</p>
+      <pre><code>$ zshield block tracker.example.com</code></pre>
+
+    </div>
+
+    <footer class="footer">
+      <p>Open source. MIT licensed.</p>
+      <p><a href="https://zarlcorp.github.io">zarlcorp.github.io</a></p>
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>zshield — DNS-level tracker and ad blocking.</title>
+  <meta name="description" content="DNS-level tracker and ad blocking. See what's tracking you, then kill it.">
+  <link rel="stylesheet" href="https://zarlcorp.github.io/shared.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+
+    <nav class="nav">
+      <a href="https://zarlcorp.github.io" class="nav-brand">zarlcorp</a>
+      <a href="docs.html">Docs</a>
+      <a href="https://github.com/zarlcorp/zshield">GitHub</a>
+    </nav>
+
+    <header class="hero">
+      <div class="logo">zshield</div>
+      <div class="tagline">DNS-level tracker and ad blocking. See what's tracking you, then kill it.</div>
+      <div class="status-badge"><span class="badge">coming soon</span></div>
+    </header>
+
+    <section class="features">
+      <ul class="feature-list">
+        <li>Local DNS resolver blocking trackers and ads</li>
+        <li>Blocklist management (community lists + custom rules)</li>
+        <li>Real-time query log with TUI dashboard</li>
+        <li>Per-domain allow/deny overrides</li>
+        <li>Statistics: blocked vs allowed, top blocked domains</li>
+        <li>Runs as daemon with TUI attach</li>
+      </ul>
+    </section>
+
+    <footer class="footer">
+      <p>Open source. MIT licensed.</p>
+      <p><a href="https://github.com/zarlcorp/zshield">github.com/zarlcorp/zshield</a></p>
+    </footer>
+
+  </div>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,26 @@
+/* zshield — page-specific overrides */
+/* shared design system lives at zarlcorp.github.io/shared.css */
+
+/* hero tuning — keep everything in a single viewport */
+
+.hero {
+  padding: 3rem 0 1.5rem;
+}
+
+.status-badge {
+  margin-top: 1rem;
+}
+
+/* features section */
+
+.features {
+  padding: 0.5rem 0 1rem;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+/* footer spacing — tighter for single viewport */
+
+.footer {
+  padding: 1.5rem 0 2rem;
+}


### PR DESCRIPTION
Closes #4

Adds docs/index.html (single-viewport landing page with Coming Soon status) and docs/docs.html (planned CLI documentation). Uses shared CSS design system from zarlcorp.github.io.

Spec: zarlcorp/core/.manager/specs/057-zshield-pages.md