### PR TITLE
add GitHub Pages link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ make run
 
 ## Learn More
 
+- [Website](https://zarlcorp.github.io/zshield) — Documentation and install instructions
 - [zarlcorp/core](https://github.com/zarlcorp/core) — Shared Go packages
 - [MANIFESTO.md](https://github.com/zarlcorp/core/blob/main/MANIFESTO.md) — Philosophy and architecture
 


### PR DESCRIPTION
Adds a link to https://zarlcorp.github.io/zshield in the Learn More section.